### PR TITLE
opensmtpd_virtual_user=None is still defined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
       - "'home' in opensmtpd_virtual_user"
       - opensmtpd_virtual_user.home | length > 0
   when:
-    - opensmtpd_virtual_user is defined
+    - opensmtpd_virtual_user
 
 - name: Assert items in opensmtpd_tables have mandatory keys
   assert:
@@ -65,7 +65,7 @@
     name: "{{ opensmtpd_virtual_user.group }}"
     state: present
   when:
-    - opensmtpd_virtual_user is defined
+    - opensmtpd_virtual_user
 
 - name: Create opensmtpd_virtual_user
   user:
@@ -79,7 +79,7 @@
     shell: /sbin/nologin
     uid: "{{ opensmtpd_virtual_user.uid | default(omit) }}"
   when:
-    - opensmtpd_virtual_user is defined
+    - opensmtpd_virtual_user
 
 - name: Create opensmtpd_tables
   template:


### PR DESCRIPTION
In ansible 2.4.3.0 and similar at least, when a var is set to None or really any value it appears to be defined. It was, therefore, trying to do the user on every run regardless of me setting it or not.

There were multiple solutions including testing for none but just checking the variable itself appears to fix the issue in the simplest way.

I've confirmed this skips when I don't have a var override set and creates the user properly when I do. I don't have older versions of ansible to test on whether the behavior is different there.