### PR TITLE
[bugfix] opensmtpd_virtual_user defaults to an empty dict, instead of `None`

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -82,3 +82,12 @@ suites:
     includes:
       - freebsd-11.1-amd64
       - openbsd-6.2-amd64
+  - name: without_virtual_user
+    provisioner:
+      name: ansible_playbook
+      playbook: tests/serverspec/without_virtual_user.yml
+    verifier:
+      name: shell
+      command: rspec -c -f d -I tests/serverspec tests/serverspec/without_virtual_user_spec.rb
+    includes:
+      - freebsd-11.1-amd64

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
 source "https://rubygems.org"
 
 gem "infrataster", "~> 0.3.2", git: "https://github.com/trombik/infrataster.git", branch: "reallyenglish"
-gem "kitchen-ansible", "~> 0.40.1", git: "https://github.com/trombik/kitchen-ansible.git", branch: "freebsd_support" # use patched kitchen-ansible
+gem "kitchen-ansible", "~> 0.48"
 gem "kitchen-sync", "~> 2.1.1", git: "https://github.com/trombik/kitchen-sync.git", branch: "without_full_path_to_rsync"
 gem "kitchen-vagrant", "~> 0.20.0"
-gem "kitchen-verifier-serverspec", "~> 0.3.0"
 gem "kitchen-verifier-shell", "~> 0.2.0"
 gem "rake", "~> 11.1.2"
 gem "rspec", "~> 3.4.0"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ must have been available, usually via `requirements.yml`.
 | `opensmtpd_extra_packages` | list of extra packages to install | `[]` |
 | `opensmtpd_config` | content of `smtpd.conf(5)` | `""` |
 | `opensmtpd_makemap_bin` | path to `makemap(8)` | `{{ __opensmtpd_makemap_bin }}` |
-| `opensmtpd_virtual_user` | Virtual user for delivering mails to virtual users. See below. | `None` |
+| `opensmtpd_virtual_user` | Virtual user for delivering mails to virtual users. See below. | `{}` |
 | `opensmtpd_extra_groups` | Additional list of groups to add `smtpd(8)` user to | `[]` |
 | `opensmtpd_tables` | list of tables. See below.  | `[]` |
 | `opensmtpd_include_x509_certificate` | Include [`trombik.x509-certificate`](https://github.com/trombik/ansible-role-x509-certificate) role during the play | `no` |
@@ -29,7 +29,7 @@ must have been available, usually via `requirements.yml`.
 ## `opensmtpd_virtual_user`
 
 This dict variable defines a virtual user to create. Its keys are explained
-below. When defined, the user and its home directory are created.
+below. When non-empty dict, the user and its home directory are created.
 
 | Key | Description | Mandatory? |
 |-----|-------------|------------|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,7 +8,7 @@ opensmtpd_package_name: "{{ __opensmtpd_package_name }}"
 opensmtpd_extra_packages: []
 opensmtpd_config: ""
 opensmtpd_makemap_bin: "{{ __opensmtpd_makemap_bin }}"
-opensmtpd_virtual_user: None
+opensmtpd_virtual_user: {}
 opensmtpd_extra_groups: []
 opensmtpd_tables: []
 opensmtpd_include_x509_certificate: no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
       - "'home' in opensmtpd_virtual_user"
       - opensmtpd_virtual_user.home | length > 0
   when:
-    - opensmtpd_virtual_user is defined
+    - opensmtpd_virtual_user
 
 - name: Assert items in opensmtpd_tables have mandatory keys
   assert:
@@ -35,7 +35,8 @@
   when:
     - opensmtpd_tables | length > 0
 
-- include_tasks: "install-{{ ansible_os_family }}.yml"
+- name: Install opensmtpd_package_name
+  include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - include_role:
     name: trombik.x509-certificate
@@ -65,7 +66,7 @@
     name: "{{ opensmtpd_virtual_user.group }}"
     state: present
   when:
-    - opensmtpd_virtual_user is defined
+    - opensmtpd_virtual_user
 
 - name: Create opensmtpd_virtual_user
   user:
@@ -79,7 +80,7 @@
     shell: /sbin/nologin
     uid: "{{ opensmtpd_virtual_user.uid | default(omit) }}"
   when:
-    - opensmtpd_virtual_user is defined
+    - opensmtpd_virtual_user
 
 - name: Create opensmtpd_tables
   template:

--- a/tests/serverspec/without_virtual_user.yml
+++ b/tests/serverspec/without_virtual_user.yml
@@ -1,0 +1,23 @@
+- hosts: localhost
+  roles:
+    - ansible-role-opensmtpd
+  vars:
+    # a test case when opensmtpd_virtual_user is an empty dict
+    # https://github.com/trombik/ansible-role-opensmtpd/pull/35
+    opensmtpd_tables:
+      - name: domains
+        path: "{{ opensmtpd_conf_dir }}/domains"
+        type: file
+        owner: root
+        group: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}wheel{% else %}root{% endif %}"
+        mode: "0644"
+        no_log: no
+        values:
+          - example.org
+    opensmtpd_config: |
+      {% for list in opensmtpd_tables %}
+      table {{ list.name }} {{ list.type }}:{{ list.path }}{% if list['type'] == 'db' %}.db{% endif %}
+
+      {% endfor %}
+      listen on {% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}lo0{% else %}lo{% endif %} port 25
+      accept from any for domain <domains> deliver to mbox

--- a/tests/serverspec/without_virtual_user_spec.rb
+++ b/tests/serverspec/without_virtual_user_spec.rb
@@ -1,0 +1,156 @@
+require "spec_helper"
+require "serverspec"
+
+service = "smtpd"
+config_dir = "/etc/mail"
+ports = [25]
+default_user = "root"
+default_group = "root"
+user = "_smtpd"
+group = "_smtpd"
+packages = []
+
+case os[:family]
+when "ubuntu"
+  config_dir = "/etc"
+  user = "opensmtpd"
+  group = "opensmtpd"
+  service = "opensmtpd"
+  packages = ["opensmtpd"]
+when "freebsd"
+  config_dir = "/usr/local/etc/mail"
+  default_group = "wheel"
+  packages = ["opensmtpd"]
+when "openbsd"
+  default_group = "wheel"
+  packages = []
+end
+
+config = "#{config_dir}/smtpd.conf"
+tables = [
+  { path: "#{config_dir}/domains",
+    name: "domains",
+    type: "file",
+    mode: 644,
+    owner: default_user,
+    group: default_group,
+    matches: [/^example\.org$/] }
+]
+
+packages.each do |p|
+  describe package p do
+    it { should be_installed }
+  end
+end
+
+case os[:family]
+when "freebsd"
+  describe file("/etc/rc.conf.d/smtpd") do
+    it { should exist }
+    it { should be_file }
+    it { should be_owned_by default_user }
+    it { should be_grouped_into default_group }
+    it { should be_mode 644 }
+    its(:content) { should match(/^smtpd_config="#{Regexp.escape(config)}"$/) }
+    its(:content) { should match(/^smtpd_flags=""$/) }
+  end
+
+  describe file("/etc/rc.conf") do
+    it { should exist }
+    it { should be_file }
+    it { should be_owned_by default_user }
+    it { should be_grouped_into default_group }
+    it { should be_mode 644 }
+    %w[sendmail_submit sendmail_outbound sendmail_msp_queue].each do |s|
+      its(:content) { should match(/^#{s}_enable='NO'$/) }
+    end
+  end
+end
+
+describe file(config_dir) do
+  it { should exist }
+  it { should be_directory }
+  it { should be_mode 755 }
+  it { should be_owned_by default_user }
+  it { should be_grouped_into default_group }
+end
+
+describe group(group) do
+  it { should exist }
+end
+
+describe user(user) do
+  it { should exist }
+  it { should belong_to_primary_group group }
+end
+
+describe file(config_dir) do
+  it { should exist }
+  it { should be_directory }
+  it { should be_mode 755 }
+  it { should be_owned_by default_user }
+  it { should be_grouped_into default_group }
+end
+
+tables.each do |t|
+  describe file(t[:path]) do
+    it { should exist }
+    it { should be_owned_by t[:owner] }
+    it { should be_grouped_into t[:group] }
+    it { should be_mode t[:mode] }
+    t[:matches].each do |m|
+      its(:content) { should match m }
+    end
+  end
+end
+
+tables.each do |t|
+  next unless t[:type] == "db"
+  describe file("#{t[:path]}.db") do
+    it { should exist }
+    it { should be_file }
+    it { should be_owned_by t[:owner] }
+    it { should be_grouped_into t[:group] }
+    it { should be_mode t[:mode] }
+  end
+end
+
+describe file(config) do
+  it { should exist }
+  it { should be_file }
+  it { should be_mode 644 }
+  it { should be_owned_by default_user }
+  it { should be_grouped_into default_group }
+  tables.each do |t|
+    path = t[:type] == "db" ? "#{t[:path]}.db" : t[:path]
+    its(:content) { should match(/^table #{t[:name]} #{t[:type]}:#{path}$/) }
+  end
+  int_lo = case os[:family]
+           when "ubuntu"
+             "lo"
+           else
+             "lo0"
+           end
+  its(:content) { should match(/^listen on #{int_lo} port 25$/) }
+  its(:content) { should match(/^#{Regexp.escape("accept from any for domain <domains> deliver to mbox")}$/) }
+end
+
+case os[:family]
+when "openbsd"
+  describe command("rcctl get smtpd flags") do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should eq "\n" }
+    its(:stderr) { should eq "" }
+  end
+end
+
+describe service(service) do
+  it { should be_running }
+  it { should be_enabled }
+end
+
+ports.each do |p|
+  describe port(p) do
+    it { should be_listening }
+  end
+end


### PR DESCRIPTION
for whatever reason, when `opensmtpd_virtual_user` is `None`,
`opensmtpd_virtual_user is defined` evaluates to true.
    
`None` is really confusing and should not be used as default value.
    
initial patch from @eby, tweaks and tests by me
https://github.com/trombik/ansible-role-opensmtpd/pull/35