### PR TITLE
[bugfix] stop smtpd(8) on ubuntu when, and only if, the package has been installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Configure `smtpd(8)`, aka [OpenSMTPD](https://www.opensmtpd.org/).
 When `opensmtpd_include_x509_certificate` is `yes`, `trombik.x509-certificate`
 must have been available, usually via `requirements.yml`.
 
+If `opensmtpd-extras` is installed, `opensmtpd` API version must match
+`opensmtpd-extras`'s one.
+
 # Role Variables
 
 | Variable | Description | Default |

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -3,6 +3,20 @@
 - name: Install opensmtpd
   apt:
     name: "{{ opensmtpd_package_name }}"
+  register: __register_opensmtpd_apt
+
+- name: Stop smtpd after initial installation of the package
+  # XXX debian-family always starts daemon when a package has been installed,
+  # which sometimes causes side-effects during ansible play. teach them to
+  # behave like other distribiutions.
+  #
+  # as practices like this have never been implemented in other roles, it
+  # might cause unexpected side-effects.
+  service:
+    name: "{{ opensmtpd_service }}"
+    state: stopped
+  when:
+    - __register_opensmtpd_apt.changed
 
 - name: Enable opensmtpd
   service:

--- a/tests/integration/relay_test/server.yml
+++ b/tests/integration/relay_test/server.yml
@@ -9,9 +9,11 @@
 
   pre_tasks:
   roles:
-    - trombik.pf
-    - trombik.x509-certificate
-    - ansible-role-opensmtpd
+    - role: trombik.pf
+      when:
+        - ansible_os_family == 'OpenBSD'
+    - role: trombik.x509-certificate
+    - role: ansible-role-opensmtpd
   vars:
     pf_rule: |
       set skip on { lo }
@@ -19,6 +21,7 @@
       # block any out-going SMTP session
       block quick on egress proto tcp from (egress) to any port smtp
       pass
+    smtp_interface: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}em1{% else %}eth1{% endif %}"
     opensmtpd_virtual_user:
       name: vmail
       group: vmail
@@ -38,7 +41,6 @@
         path: "{{ opensmtpd_conf_dir }}/domains"
         type: file
         owner: root
-        group: wheel
         mode: "0644"
         no_log: no
         values:
@@ -76,9 +78,8 @@
       table {{ list.name }} {{ list.type }}:{{ list.path }}{% if list['type'] == 'db' %}.db{% endif %}
 
       {% endfor %}
-      listen on em1 port 25
-      listen on em1 port 587 smtps pki a.mx.trombik.org auth <secrets> hostname \
-        a.mx.trombik.org received-auth
+      listen on {{ smtp_interface }} port 25
+      listen on {{ smtp_interface }} port 587 smtps pki a.mx.trombik.org auth <secrets> hostname a.mx.trombik.org received-auth
 
       accept authenticated for any relay
       accept from any for domain <domains> virtual <virtuals> \

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -8,7 +8,7 @@
     # XXX table_passwd in Ubuntu package throws error when UID or GID field is
     # empty
     passwd_postfix: "{% if ansible_os_family == 'Debian' %}:12345:12345:::{% else %}:::::{% endif %}"
-    opensmtpd_extra_packages: "{% if ansible_os_family == 'FreeBSD' %}[ 'opensmtpd-extras-table-passwd' ]{% else %}[ 'opensmtpd-extras' ]{% endif %}"
+    opensmtpd_extra_packages: "{% if ansible_os_family == 'FreeBSD' %}[ 'opensmtpd-extras-table-passwd' ]{% elif ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04' %}[]{% else %}[ 'opensmtpd-extras' ]{% endif %}"
     opensmtpd_extra_groups: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}[ 'nobody' ]{% else %}[ 'games' ]{% endif %}"
     opensmtpd_virtual_user:
       name: vmail
@@ -88,7 +88,15 @@
     opensmtpd_flags: -v
     opensmtpd_config: |
       {% for list in opensmtpd_tables %}
+      {% if list.type == 'passwd' and ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04' %}
+      # XXX at the moment (2018/05/20), the version of opensmtpd-extras is
+      # behind opensmtpd, causing "table-api: bad API version".
+      # https://packages.ubuntu.com/xenial/mail/opensmtpd-extras
+      #
+      # skip passwd table until synced version is released
+      {% else %}
       table {{ list.name }} {{ list.type }}:{{ list.path }}{% if list['type'] == 'db' %}.db{% endif %}
+      {% endif %}
 
       {% endfor %}
       listen on {% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}lo0{% else %}lo{% endif %} port 25

--- a/tests/serverspec/default.yml
+++ b/tests/serverspec/default.yml
@@ -8,7 +8,7 @@
     # XXX table_passwd in Ubuntu package throws error when UID or GID field is
     # empty
     passwd_postfix: "{% if ansible_os_family == 'Debian' %}:12345:12345:::{% else %}:::::{% endif %}"
-    opensmtpd_extra_packages: "{% if ansible_os_family == 'FreeBSD' %}[ 'opensmtpd-extras-table-passwd' ]{% elif ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04' %}[]{% else %}[ 'opensmtpd-extras' ]{% endif %}"
+    opensmtpd_extra_packages: "{% if ansible_os_family == 'FreeBSD' %}[ 'opensmtpd-extras-table-passwd' ]{% elif ansible_distribution == 'Ubuntu' and (ansible_distribution_version == '18.04' or ansible_distribution_version == '14.04') %}[]{% else %}[ 'opensmtpd-extras' ]{% endif %}"
     opensmtpd_extra_groups: "{% if ansible_os_family == 'FreeBSD' or ansible_os_family == 'OpenBSD' %}[ 'nobody' ]{% else %}[ 'games' ]{% endif %}"
     opensmtpd_virtual_user:
       name: vmail
@@ -88,12 +88,14 @@
     opensmtpd_flags: -v
     opensmtpd_config: |
       {% for list in opensmtpd_tables %}
-      {% if list.type == 'passwd' and ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04' %}
+      {% if list.type == 'passwd' and ansible_distribution == 'Ubuntu' and (ansible_distribution_version == '18.04' or ansible_distribution_version == '14.04') %}
       # XXX at the moment (2018/05/20), the version of opensmtpd-extras is
       # behind opensmtpd, causing "table-api: bad API version".
-      # https://packages.ubuntu.com/xenial/mail/opensmtpd-extras
+      # https://packages.ubuntu.com/bionic/opensmtpd-extras
       #
       # skip passwd table until synced version is released
+      #
+      # also, opensmtpd-extras for ubuntu 14.04 was removed
       {% else %}
       table {{ list.name }} {{ list.type }}:{{ list.path }}{% if list['type'] == 'db' %}.db{% endif %}
       {% endif %}

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -94,7 +94,12 @@ tables = [
 
 packages.each do |p|
   describe package p do
-    it { should be_installed }
+    it do
+      if p == 'opensmtpd-extras' && os[:family] == "ubuntu" && os[:release].to_f == 14.04
+        pending "the package is not available"
+      end
+      should be_installed
+    end
   end
 end
 
@@ -201,7 +206,7 @@ describe file(config) do
   tables.each do |t|
     path = t[:type] == "db" ? "#{t[:path]}.db" : t[:path]
     its(:content) do
-      if t[:name] == "passwd" && os[:family] == "ubuntu" && os[:release].to_f == 18.04
+      if t[:name] == "passwd" && os[:family] == "ubuntu" && (os[:release].to_f == 18.04 || os[:release].to_f == 14.04)
         pending "ubuntu 16.04 does not have matched version of opensmtpd-extra"
       end
       should match(/^table #{t[:name]} #{t[:type]}:#{path}$/)

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -95,7 +95,7 @@ tables = [
 packages.each do |p|
   describe package p do
     it do
-      if p == 'opensmtpd-extras' && os[:family] == "ubuntu" && os[:release].to_f == 14.04
+      if p == "opensmtpd-extras" && os[:family] == "ubuntu" && os[:release].to_f == 14.04
         pending "the package is not available"
       end
       should be_installed

--- a/tests/serverspec/default_spec.rb
+++ b/tests/serverspec/default_spec.rb
@@ -200,7 +200,12 @@ describe file(config) do
   it { should be_grouped_into default_group }
   tables.each do |t|
     path = t[:type] == "db" ? "#{t[:path]}.db" : t[:path]
-    its(:content) { should match(/^table #{t[:name]} #{t[:type]}:#{path}$/) }
+    its(:content) do
+      if t[:name] == "passwd" && os[:family] == "ubuntu" && os[:release].to_f == 18.04
+        pending "ubuntu 16.04 does not have matched version of opensmtpd-extra"
+      end
+      should match(/^table #{t[:name]} #{t[:type]}:#{path}$/)
+    end
   end
   int_lo = case os[:family]
            when "ubuntu"


### PR DESCRIPTION
this debian-specific behavior has been problematic. daemons are started
without user's consent, causing conflicts during ansible play while the
daemon is running with debian's default configuration.

this is not a cause of #37, but it possibly is a good practice for roles.

i cannot think of any side-effects, but debian family assumes daemons
are started right after packages have been installed. this might
surprise the distribution somehow.

also, fix bugs found during the investigation of #37.